### PR TITLE
Enable no_std on rust stable by removing unused feature flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safe-mix"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 description = "Implementation of the Collective Coin Flip algorithm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 //! Described in http://www.cs.huji.ac.il/~nati/PAPERS/coll_coin_fl.pdf
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(core_intrinsics))]
 
 #[cfg(feature = "std")]
 use std::ops::{BitAnd, BitOr};


### PR DESCRIPTION
Changes:

- Remove #[feature(core_intrinsics))] as core::intrinsics is never used.
- Bump version in Cargo.toml to make it easy to publish the change to crates.io